### PR TITLE
fix auth token when send preheat request

### DIFF
--- a/src/distribution/controller.go
+++ b/src/distribution/controller.go
@@ -397,15 +397,15 @@ func buildImageData(image models.ImageRepository) (*provider.PreheatImage, error
 		return nil, err
 	}
 
-	extURL, err := config.ExtURL()
-	if err != nil {
-		return nil, err
-	}
+	// extURL, err := config.ExtURL()
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	access := []*rtoken.ResourceActions{&rtoken.ResourceActions{
 		Type:    "repository",
-		Name:    fmt.Sprintf("%s/%s", extURL, image.Name()),
-		Actions: []string{"pull"},
+		Name:    fmt.Sprintf("%s", image.Name()),
+		Actions: []string{"pull", "push", "*"},
 	}}
 
 	tk, err := token.MakeToken("distributor", token.Registry, access)


### PR DESCRIPTION
This fix the 401 - auth token invalid error when send as Auth header to Dragonfly preheat API